### PR TITLE
Overflow Account.ID in 32bit systems fix

### DIFF
--- a/request.go
+++ b/request.go
@@ -222,7 +222,7 @@ func (insta *Instagram) sendRequest(o *reqOptions) (body []byte, h http.Header, 
 		"X-Fb-Server-Cluster":         "True",
 	}
 	if insta.Account != nil {
-		headers["Ig-Intended-User-Id"] = strconv.Itoa(int(insta.Account.ID))
+		headers["Ig-Intended-User-Id"] = strconv.FormatInt(insta.Account.ID, 10)
 	} else {
 		headers["Ig-Intended-User-Id"] = "0"
 	}


### PR DESCRIPTION
I faced issues with immediately logout after login request. This is caused by casting int64 to int on adding authorization header (Ig-Intended-User-Id) while compiling it for arm32. Potentially fixes builds for other 32-bit systems.