### PR TITLE
Fix reels in inbox

### DIFF
--- a/inbox.go
+++ b/inbox.go
@@ -97,7 +97,7 @@ type InboxItem struct {
 	TqSeqID       int    `json:"tq_seq_id"`
 
 	// Type there are a few types:
-	// text, like, raven_media, action_log, media_share, reel_share, link
+	// text, like, raven_media, action_log, media_share, reel_share, link, clip
 	Type string `json:"item_type"`
 
 	// Text is message text.
@@ -108,6 +108,7 @@ type InboxItem struct {
 
 	Like string `json:"like"`
 
+	Clip          *clip          `json:"clip"`
 	Reel          *reelShare     `json:"reel_share"`
 	Media         *Item          `json:"media"`
 	MediaShare    *Item          `json:"media_share"`
@@ -162,6 +163,10 @@ type reelShare struct {
 	Type        string `json:"type"`
 	ReelType    string `json:"reel_type"`
 	Media       Item   `json:"media"`
+}
+
+type clip struct {
+	Media Item `json:"clip"`
 }
 
 type actionLog struct {


### PR DESCRIPTION
I noticed that the current impl of reels don't work we don't get the information related to a sended reels through private message.
So i investigate and i found out that instagram named it as `clip` in their JSONs