### PR TITLE
Fix infinite loop while fetching user followers

### DIFF
--- a/users.go
+++ b/users.go
@@ -98,6 +98,8 @@ func (users *Users) Next() bool {
 			return false
 		}
 		users.NextID = strconv.FormatInt(nextID, 10)
+	} else {
+		users.NextID = ""
 	}
 
 	users.Status = newUsers.Status


### PR DESCRIPTION
While fetching many pages of followers, NextID is not cleaned after last iteration. This causes infinite fetching of last page.