### PR TITLE
Use filepath.Split instead of path.Split so DownloadTo works on windows

### DIFF
--- a/media.go
+++ b/media.go
@@ -8,6 +8,7 @@ import (
 	neturl "net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -666,7 +667,7 @@ func (item *Item) changeLike(endpoint string) error {
 // }
 func (item *Item) DownloadTo(dst string) error {
 	insta := item.insta
-	folder, file := path.Split(dst)
+	folder, file := filepath.Split(dst)
 
 	if err := os.MkdirAll(folder, 0o777); err != nil {
 		return err


### PR DESCRIPTION
I had to add this to get the DownloadTo to work on windows. It should be cross platform compatible.