### PR TITLE
Fix warnhandler formatting for 429 error

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -77,7 +77,7 @@ func (w *Wrapper) GoInstaWrapper(o *ReqWrapperArgs) ([]byte, http.Header, error)
 		if o.Ignore429() {
 			return o.Body, o.Headers, nil
 		}
-			insta.warnHandler("Too many requests, sleeping for %d seconds", TooManyRequestsTimeout)
+			insta.warnHandler("Too many requests, sleeping for %d seconds", int(TooManyRequestsTimeout.Seconds()))
 			time.Sleep(TooManyRequestsTimeout)
 
 	case errors.Is(o.Error, Err2FARequired):


### PR DESCRIPTION
Call the seconds method on TooManyRequestsTimeout duration and cast to int. I do this because without it the arguments passed to the warnhandler do not match. The format string contains %d but the argument type is not an int (see https://go.dev/play/p/i79DM3YPdoo) 